### PR TITLE
Add catch for eval errors when using the show_if_custom_php option

### DIFF
--- a/CustomInputfieldDependencies.module
+++ b/CustomInputfieldDependencies.module
@@ -11,7 +11,7 @@ class CustomInputfieldDependencies extends WireData implements Module {
 		return array(
 			'title' => 'Custom Inputfield Dependencies',
 			'summary' => 'Extends inputfield dependencies so that inputfield visibility or required status may be determined at runtime by selector or custom PHP code.',
-			'version' => '0.3.0',
+			'version' => '0.3.1',
 			'href' => 'https://github.com/Toutouwai/CustomInputfieldDependencies',
 			'icon' => 'eye',
 			'autoload' => 'template=admin',
@@ -126,14 +126,10 @@ class CustomInputfieldDependencies extends WireData implements Module {
 				if($result !== true) {
 					$this->hideInputfield($inputfield, $field);
 				}
-			} catch (ParseError $e) {
-				if ($this->wire()->user->isSuperuser()) {
-					$fieldName = $field->name;
-					$error = $e->getMessage();
-
-					$this->wire()->error(
-						"The 'Show only if custom PHP returns true' code provided for field '{$fieldName}' generated an error: {$error}"
-					);
+			} catch(ParseError $e) {
+				if($this->wire()->user->isSuperuser()) {
+					$error = sprintf($this->_('The "Show only if custom PHP returns true" code provided for field "%s" generated an error: %s'), $field->name, $e->getMessage());
+					$this->wire()->error($error);
 				}
 			}
 		}

--- a/CustomInputfieldDependencies.module
+++ b/CustomInputfieldDependencies.module
@@ -1,5 +1,7 @@
 <?php namespace ProcessWire;
 
+use ParseError;
+
 class CustomInputfieldDependencies extends WireData implements Module {
 
 	/**
@@ -103,7 +105,7 @@ class CustomInputfieldDependencies extends WireData implements Module {
 		if(!$page->id) $page = $process->getPage();
 
 		// Mainly to make this variable available as $pages in custom PHP
-		$pages = $this->wire()->pages; 
+		$pages = $this->wire()->pages;
 
 		// Evaluate show-if conditions
 		if($field->show_if_custom_find) {
@@ -119,9 +121,20 @@ class CustomInputfieldDependencies extends WireData implements Module {
 			}
 		}
 		if($field->show_if_custom_php) {
-			$result = eval($field->show_if_custom_php);
-			if($result !== true) {
-				$this->hideInputfield($inputfield, $field);
+			try {
+				$result = eval($field->show_if_custom_php);
+				if($result !== true) {
+					$this->hideInputfield($inputfield, $field);
+				}
+			} catch (ParseError $e) {
+				if ($this->wire()->user->isSuperuser()) {
+					$fieldName = $field->name;
+					$error = $e->getMessage();
+
+					$this->wire()->error(
+						"The 'Show only if custom PHP returns true' code provided for field '{$fieldName}' generated an error: {$error}"
+					);
+				}
 			}
 		}
 


### PR DESCRIPTION
Executing show-if PHP that contains invalid syntax generates an error that is inescapable when editing a page and the stack trace doesn't help find where/which field the error occurred on.

In my case I had a bunch of tabs open and didn't remember which field I had made the change on when loading a page to edit.

I added a try/catch that handles the ParseError that generates an admin warning message for superusers.

Before/after:

![custom_inputfield_dependencies_parse_error](https://github.com/user-attachments/assets/0cc20b76-d475-4062-812d-f4888bcc4e22)

![image](https://github.com/user-attachments/assets/335a324f-b2a8-4acb-807c-addf9272aca0)

